### PR TITLE
Multilang - Provider Decoder Improvements

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/AwsCredentialsProviderPropertyValueDecoder.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/AwsCredentialsProviderPropertyValueDecoder.java
@@ -176,7 +176,7 @@ class AwsCredentialsProviderPropertyValueDecoder implements IPropertyValueDecode
     }
 
     /**
-     * Resolves the class for the given provider name and arguments.
+     * Resolves the class for the given provider name.
      *
      * @param providerName A string containing the provider name.
      *

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/AwsCredentialsProviderPropertyValueDecoder.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/AwsCredentialsProviderPropertyValueDecoder.java
@@ -175,6 +175,14 @@ class AwsCredentialsProviderPropertyValueDecoder implements IPropertyValueDecode
         return null;
     }
 
+    /**
+     * Resolves the class for the given provider name and arguments.
+     *
+     * @param providerName A string containing the provider name.
+     *
+     * @return The Class object representing the resolved AwsCredentialsProvider implementation,
+     * or null if the class cannot be resolved or does not extend AwsCredentialsProvider.
+     */
     private static Class<? extends AwsCredentialsProvider> getClass(String providerName) {
         String className = providerName.replace(
                 "software.amazon.awssdk.auth.credentials.StsAssumeRoleCredentialsProvider",

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/AwsCredentialsProviderPropertyValueDecoder.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/AwsCredentialsProviderPropertyValueDecoder.java
@@ -27,6 +27,8 @@ import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.kinesis.multilang.auth.KclStsAssumeRoleCredentialsProvider;
 
 /**
  * Get AwsCredentialsProvider property.
@@ -184,12 +186,14 @@ class AwsCredentialsProviderPropertyValueDecoder implements IPropertyValueDecode
      * or null if the class cannot be resolved or does not extend AwsCredentialsProvider.
      */
     private static Class<? extends AwsCredentialsProvider> getClass(String providerName) {
-        String className = providerName.replace(
-                "software.amazon.awssdk.auth.credentials.StsAssumeRoleCredentialsProvider",
-                "software.amazon.kinesis.multilang.auth.KclStsAssumeRoleCredentialsProvider");
+        // Convert any form of StsAssumeRoleCredentialsProvider string to KclStsAssumeRoleCredentialsProvider
+        if (providerName.equals(StsAssumeRoleCredentialsProvider.class.getSimpleName())
+                || providerName.equals(StsAssumeRoleCredentialsProvider.class.getName())) {
+            providerName = KclStsAssumeRoleCredentialsProvider.class.getName();
+        }
         final Class<? extends AwsCredentialsProvider> clazz;
         try {
-            final Class<?> c = Class.forName(className);
+            final Class<?> c = Class.forName(providerName);
             if (!AwsCredentialsProvider.class.isAssignableFrom(c)) {
                 return null;
             }

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/AWSCredentialsProviderPropertyValueDecoderTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/AWSCredentialsProviderPropertyValueDecoderTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.kinesis.multilang.auth.KclStsAssumeRoleCredentialsProvider;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -121,7 +122,8 @@ public class AWSCredentialsProviderPropertyValueDecoderTest {
         for (final String className : Arrays.asList(
                 KclStsAssumeRoleCredentialsProvider.class.getName(), // fully-qualified name
                 KclStsAssumeRoleCredentialsProvider.class.getSimpleName(), // name-only; needs prefix
-                "software.amazon.awssdk.auth.credentials.StsAssumeRoleCredentialsProvider")) {
+                StsAssumeRoleCredentialsProvider.class.getName(), // user passes full sts package path
+                StsAssumeRoleCredentialsProvider.class.getSimpleName())) {
             final AwsCredentialsProvider provider = decoder.decodeValue(className + "|arn|sessionName");
             assertNotNull(className, provider);
         }

--- a/docs/multilang/configuring-credential-providers.md
+++ b/docs/multilang/configuring-credential-providers.md
@@ -7,22 +7,27 @@ However, KCL now provides better extensibility to handle, and be enhanced to han
 This document should help multilang customers configure a suitable `CredentialProvider` (or contribute changes to support a new use case!).
 
 ## Sample Provider Configuration
-DEPRECATED: StsAssumeRoleCredentialsProvider can no longer be constructed in this way:
-```
-AWSCredentialsProvider = StsAssumeRoleCredentialsProvider|<arn>|<sessionName>`
-```
 
-To create a [StsAssumeRoleCredentialsProvider][sts-assume-provider], see KclStsAssumeRoleCredentialsProvider below.
+In a Properties file, an `AWSCredentialsProperty` configuration might look like:
+```
+AWSCredentialsProvider = StsAssumeRoleCredentialsProvider|<arn>|<sessionName> 
+```
+This basic configuration creates an [StsAssumeRoleCredentialsProvider][sts-assume-provider] with an ARN and session name.
 
-You can create a default [DefaultCredentialsProvider][default-credentials-provider] or [AnonymousCredentialsProvider][anonymous-credentials-provider]
-by passing it in the config like:
+While functional, this configuration is limited.
+For example, this configuration cannot set a regional endpoint (e.g., VPC use case).
+
+Leveraging nested properties, an `AWSCredentialsProperty` value might change to:
+```
+AWSCredentialsProvider = KclSTSAssumeRoleSessionCredentialsProvider|<arn>|<sessionName>\
+    |endpointRegion=us-east-1|externalId=spartacus
+```
+N.B. Backslash (`\`) is for multi-line legibility and is not required.
+
+You can create a default [DefaultCredentialsProvider][default-credentials-provider] by passing it in the config like:
 ```
 AWSCredentialsProvider = DefaultCredentialsProvider
 ```
-
-If you wish to customize properties on an AWS SDK provider that uses a builder, like the StsASsumeRoleCredentialsProvider,
-you will need to wrap this provider class, provide a constructor, and manage the build of the provider. 
-See implementation of [KclStsAssumeRoleCredentialsProvider][kcl-sts-provider]
 
 ## Nested Properties
 
@@ -36,6 +41,10 @@ The [Backus-Naur form][bnf] of the value:
 <nested-key> ::= <lower-camel-case-key>
 <nested-value ::= <string> # this depends on the nested key
 ```
+
+In general, required parameters are passed directly to the class' constructor or .create() method
+(e.g., [ProfileCredentialsProvider(String)][profile-credentials-provider-create]). However, most of these providers
+require builders and will require a custom implementation similar to `KclStsAssumeRoleCredentialsProvider` for customization
 
 Nested properties are a custom mapping provided by KCL multilang, and do not exist in the AWS SDK.
 See [NestedPropertyKey][nested-property-key] for the supported keys, and details on their expected values.
@@ -73,5 +82,5 @@ AWSCredentialsProvider = KclStsAssumeRoleCredentialsProvider|<arn>|<sessionName>
 [nested-property-key]: /amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/NestedPropertyKey.java
 [nested-property-processor]: /amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/NestedPropertyProcessor.java
 [sts-assume-provider]: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.html
+[profile-credentials-provider-create]: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.html#create(java.lang.String)
 [default-credentials-provider]: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html
-[anonymous-credentials-provider]: https://sdk.amazonaws.com/java/api/2.0.0-preview-11/software/amazon/awssdk/auth/credentials/AnonymousCredentialsProvider.html


### PR DESCRIPTION
Upon reviewing all of the old/new providers, we can support the v1 behavior quite easily. While we originally assumed that many of the old providers were being created with some constructor like Provider(string, string...) and we were losing that functionality with them moving to builders, there were only 2 providers that could be created like Constructor(String, String...)  in the v1 SDK.

[STSAssumeRoleSessionsCredentialsProvider](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/STSAssumeRoleSessionCredentialsProvider.html#STSAssumeRoleSessionCredentialsProvider-java.lang.String-java.lang.String-)

[ProfileCredentialsProvider](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/profile/ProfileCredentialsProvider.html#ProfileCredentialsProvider-java.lang.String-)

* Adds a mapping for StsAssumeRoleCredentialsProvider -> KclStsAssumeRoleCredentialsProvider. A user can now input config string `AWSCredentialsProvider = StsAssumeRoleSessionCredentialsProvider|<arn>|<sessionName>`  and it will parse as expected because we are internally mapping this to our custom processor. Adds a test to validate this.

* ProfileCredentialsProvider has a [create(String) method](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.html#create(java.lang.String)) that takes in a profile name. Modifies the provider creator to first try a `.create(arg1)` before defaulting to `.create()`, so this version will support `AWSCredentialsProvider = ProfileCredentialsProvider|<profileName>` this as well. Adds a provider test class and tests to validate this works for both the empty `create()` and `create(String)`.

* Refactors the provider creator to attempt to invoke a constructor with args/varargs, create with args/varargs, constructor with no args, create with no args. This PR adds a try to `.create()` with args/varargs to support providers that have `.create(String...)` methods. Other code changes here are just refactors. 

* Updates documentation to reflect this.

With these changes, we support the same provider string configuration that was supported in the v1 version. We will still instruct users to create their own custom processor if they need a more configured provider, just like in the v1. 