### PR TITLE
KCL - Exclude AWS v1 SDK from Glue dependency

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -82,6 +82,12 @@
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
       <version>${gsr.version}</version>
+      <exclusions>
+          <exclusion>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>aws-java-sdk-sts</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>software.amazon.glue</groupId>


### PR DESCRIPTION
Exclude the transient dependency of AWS v1 SDK from Glue in KCL. This can be done safely, as Glue is not using this dependency for anything in the [serializer-deserialzer](https://github.com/awslabs/aws-glue-schema-registry/tree/master/serializer-deserializer) package. This has been bumped several times in [this PR](https://github.com/awslabs/aws-glue-schema-registry/pull/338) but is yet to be addressed. 

Th exclusion of the transient dependency `com.amazonaws:aws-java-sdk-sts` enables the KCL to be fully independent of the AWS SDK v1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
