### PR TITLE
Add minimum idleTimeBetweenReadsInMillis to multilang

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java
@@ -1104,10 +1104,7 @@ public class KinesisClientLibConfiguration {
      */
     public KinesisClientLibConfiguration withIdleTimeBetweenReadsInMillis(long idleTimeBetweenReadsInMillis) {
         checkIsValuePositive("IdleTimeBetweenReadsInMillis", idleTimeBetweenReadsInMillis);
-        if (idleTimeBetweenReadsInMillis < MIN_IDLE_MILLIS_BETWEEN_READS) {
-            throw new IllegalArgumentException("idleTimeBetweenReadsInMillis must be greater than or equal to "
-                    + MIN_IDLE_MILLIS_BETWEEN_READS + " but current value is " + idleTimeBetweenReadsInMillis);
-        }
+        idleTimeBetweenReadsInMillis = Math.max(idleTimeBetweenReadsInMillis, MIN_IDLE_MILLIS_BETWEEN_READS);
         this.idleTimeBetweenReadsInMillis = idleTimeBetweenReadsInMillis;
         return this;
     }

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java
@@ -71,6 +71,12 @@ public class KinesisClientLibConfiguration {
     public static final long DEFAULT_IDLETIME_BETWEEN_READS_MILLIS = 1000L;
 
     /**
+     * The minimum time {@link ShardConsumer} should sleep between calls to
+     * {@link com.amazonaws.services.kinesis.AmazonKinesis#getRecords(com.amazonaws.services.kinesis.model.GetRecordsRequest)}.
+     */
+    public static final long MIN_IDLE_MILLIS_BETWEEN_READS = 200L;
+
+    /**
      * Don't call processRecords() on the record processor for empty record lists.
      */
     public static final boolean DEFAULT_DONT_CALL_PROCESS_RECORDS_FOR_EMPTY_RECORD_LIST = false;
@@ -1098,6 +1104,10 @@ public class KinesisClientLibConfiguration {
      */
     public KinesisClientLibConfiguration withIdleTimeBetweenReadsInMillis(long idleTimeBetweenReadsInMillis) {
         checkIsValuePositive("IdleTimeBetweenReadsInMillis", idleTimeBetweenReadsInMillis);
+        if (idleTimeBetweenReadsInMillis < MIN_IDLE_MILLIS_BETWEEN_READS) {
+            throw new IllegalArgumentException("idleTimeBetweenReadsInMillis must be greater than or equal to "
+                    + MIN_IDLE_MILLIS_BETWEEN_READS + " but current value is " + idleTimeBetweenReadsInMillis);
+        }
         this.idleTimeBetweenReadsInMillis = idleTimeBetweenReadsInMillis;
         return this;
     }

--- a/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
+++ b/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
@@ -57,8 +57,8 @@ shardSyncIntervalMillis = 60000
 # Max records to fetch from Kinesis in a single GetRecords call.
 maxRecords = 10000
 
-# Idle time between record reads in milliseconds. Setting this property lower than 200ms may result in
-# ProvisionedThroughputExceededException exception if limit of 5 GetRecords calls per second per shard is exceeded.
+# Idle time between record reads in milliseconds.
+# Setting this property lower than 200ms may result in an IllegalArgumentException.
 idleTimeBetweenReadsInMillis = 1000
 
 # Enables applications flush/checkpoint (if they have some data "in progress", but don't get new data for while)

--- a/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
+++ b/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
@@ -57,7 +57,8 @@ shardSyncIntervalMillis = 60000
 # Max records to fetch from Kinesis in a single GetRecords call.
 maxRecords = 10000
 
-# Idle time between record reads in milliseconds.
+# Idle time between record reads in milliseconds. Setting this property lower than 200ms may result in
+# ProvisionedThroughputExceededException exception if limit of 5 GetRecords calls per second per shard is exceeded.
 idleTimeBetweenReadsInMillis = 1000
 
 # Enables applications flush/checkpoint (if they have some data "in progress", but don't get new data for while)

--- a/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
+++ b/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
@@ -58,7 +58,7 @@ shardSyncIntervalMillis = 60000
 maxRecords = 10000
 
 # Idle time between record reads in milliseconds.
-# Setting this property lower than 200ms may result in an IllegalArgumentException.
+# Setting this property lower than 200ms will be overwritten to 200ms.
 idleTimeBetweenReadsInMillis = 1000
 
 # Enables applications flush/checkpoint (if they have some data "in progress", but don't get new data for while)

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -26,6 +26,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.kinesis.retrieval.DataFetcherProviderConfig;
@@ -38,6 +39,7 @@ import software.amazon.kinesis.retrieval.RetrievalSpecificConfig;
 @Setter
 @ToString
 @EqualsAndHashCode
+@Slf4j
 public class PollingConfig implements RetrievalSpecificConfig {
 
     public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
@@ -144,9 +146,9 @@ public class PollingConfig implements RetrievalSpecificConfig {
      */
     public PollingConfig idleTimeBetweenReadsInMillis(long idleTimeBetweenReadsInMillis) {
         if (idleTimeBetweenReadsInMillis < MIN_IDLE_MILLIS_BETWEEN_READS) {
-            throw new IllegalArgumentException("idleTimeBetweenReadsInMillis must be greater than or equal to "
-                    + MIN_IDLE_MILLIS_BETWEEN_READS + " but current value is "
-                    + idleTimeBetweenReadsInMillis());
+            log.warn("idleTimeBetweenReadsInMillis config property is set below the minimum allowed value of 200ms."
+                    + " This value will be automatically adjusted to 200ms.\n");
+            idleTimeBetweenReadsInMillis = MIN_IDLE_MILLIS_BETWEEN_READS;
         }
         usePollingConfigIdleTimeValue = true;
         this.idleTimeBetweenReadsInMillis = idleTimeBetweenReadsInMillis;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -144,7 +144,7 @@ public class PollingConfig implements RetrievalSpecificConfig {
      */
     public PollingConfig idleTimeBetweenReadsInMillis(long idleTimeBetweenReadsInMillis) {
         if (idleTimeBetweenReadsInMillis < MIN_IDLE_MILLIS_BETWEEN_READS) {
-            throw new IllegalArgumentException("Value for idleTimeBetweenReadsInMillis must be less than or equal to "
+            throw new IllegalArgumentException("idleTimeBetweenReadsInMillis must be greater than or equal to "
                     + MIN_IDLE_MILLIS_BETWEEN_READS + " but current value is "
                     + idleTimeBetweenReadsInMillis());
         }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -44,6 +44,8 @@ public class PollingConfig implements RetrievalSpecificConfig {
 
     public static final int DEFAULT_MAX_RECORDS = 10000;
 
+    public static final long MIN_IDLE_MILLIS_BETWEEN_READS = 200L;
+
     /**
      * Configurable functional interface to override the existing DataFetcher.
      */
@@ -138,9 +140,14 @@ public class PollingConfig implements RetrievalSpecificConfig {
     /**
      * Set the value for how long the ShardConsumer should sleep in between calls to
      * {@link KinesisAsyncClient#getRecords(GetRecordsRequest)}. If this is not specified here the value provided in
-     * {@link RecordsFetcherFactory} will be used.
+     * {@link RecordsFetcherFactory} will be used. Cannot set value below MIN_IDLE_MILLIS_BETWEEN_READS
      */
     public PollingConfig idleTimeBetweenReadsInMillis(long idleTimeBetweenReadsInMillis) {
+        if (idleTimeBetweenReadsInMillis < MIN_IDLE_MILLIS_BETWEEN_READS) {
+            throw new IllegalArgumentException("Value for idleTimeBetweenReadsInMillis must be less than or equal to "
+                    + MIN_IDLE_MILLIS_BETWEEN_READS + " but current value is "
+                    + idleTimeBetweenReadsInMillis());
+        }
         usePollingConfigIdleTimeValue = true;
         this.idleTimeBetweenReadsInMillis = idleTimeBetweenReadsInMillis;
         return this;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -147,7 +147,7 @@ public class PollingConfig implements RetrievalSpecificConfig {
     public PollingConfig idleTimeBetweenReadsInMillis(long idleTimeBetweenReadsInMillis) {
         if (idleTimeBetweenReadsInMillis < MIN_IDLE_MILLIS_BETWEEN_READS) {
             log.warn("idleTimeBetweenReadsInMillis config property is set below the minimum allowed value of 200ms."
-                    + " This value will be automatically adjusted to 200ms.\n");
+                    + " This value will be automatically adjusted to 200ms.");
             idleTimeBetweenReadsInMillis = MIN_IDLE_MILLIS_BETWEEN_READS;
         }
         usePollingConfigIdleTimeValue = true;

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PollingConfigTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PollingConfigTest.java
@@ -48,4 +48,9 @@ public class PollingConfigTest {
     public void testInvalidRecordLimit() {
         config.maxRecords(PollingConfig.DEFAULT_MAX_RECORDS + 1);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidIdleMillisLimit() {
+        config.idleTimeBetweenReadsInMillis(PollingConfig.MIN_IDLE_MILLIS_BETWEEN_READS - 1);
+    }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PollingConfigTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PollingConfigTest.java
@@ -49,8 +49,9 @@ public class PollingConfigTest {
         config.maxRecords(PollingConfig.DEFAULT_MAX_RECORDS + 1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidIdleMillisLimit() {
-        config.idleTimeBetweenReadsInMillis(PollingConfig.MIN_IDLE_MILLIS_BETWEEN_READS - 1);
+    @Test
+    public void testMinIdleMillisLimit() {
+        config.idleTimeBetweenReadsInMillis(0);
+        assertEquals(config.idleTimeBetweenReadsInMillis(), PollingConfig.MIN_IDLE_MILLIS_BETWEEN_READS);
     }
 }


### PR DESCRIPTION
Implements a minimum `idleTimeBetweenReadsInMillis` to prevent users from setting `idleTimeBetweenReadsInMillis` below 200ms through `multilang.properties`, `pollingConfig` or `KinesisClientLibConfiguration`.

Overwrites `idleTimeBetweenReadsInMillis` with the 200ms if config is set below minimum. Kinesis Data Streams has a limit of 5 GetRecords calls per second per shard, so the initial minimum is set at 200ms. See note [here](https://docs.aws.amazon.com/streams/latest/dev/kinesis-low-latency.html): 

> Note
> Because Kinesis Data Streams has a limit of 5 GetRecords calls per second, per shard, setting the idleTimeBetweenReadsInMillis property lower than 200ms may result in your application observing the ProvisionedThroughputExceededException exception. Too many of these exceptions can result in exponential back-offs and thereby cause significant unexpected latencies in processing. If you set this property to be at or just above 200 ms and have more than one processing application, you will experience similar throttling.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
