### PR TITLE
Add idleMillisAfterThrottle config property for improved backoff configuration

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/PollingConfigBean.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/PollingConfigBean.java
@@ -41,6 +41,10 @@ public class PollingConfigBean implements RetrievalConfigBuilder {
 
         void setIdleTimeBetweenReadsInMillis(long value);
 
+        long getIdleMillisAfterThrottle();
+
+        void setIdleMillisAfterThrottle(long value);
+
         int getMaxRecords();
 
         void setMaxRecords(int value);
@@ -54,6 +58,9 @@ public class PollingConfigBean implements RetrievalConfigBuilder {
 
     @ConfigurationSettable(configurationClass = PollingConfig.class)
     private long idleTimeBetweenReadsInMillis;
+
+    @ConfigurationSettable(configurationClass = PollingConfig.class)
+    private long idleMillisAfterThrottle;
 
     @ConfigurationSettable(configurationClass = PollingConfig.class)
     private int maxRecords;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfigurationTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfigurationTest.java
@@ -160,6 +160,7 @@ public class MultiLangDaemonConfigurationTest {
         MultiLangDaemonConfiguration configuration = baseConfiguration();
         configuration.setMaxRecords(10);
         configuration.setIdleTimeBetweenReadsInMillis(60000);
+        configuration.setIdleMillisAfterThrottle(60000);
 
         MultiLangDaemonConfiguration.ResolvedConfiguration resolvedConfiguration =
                 configuration.resolvedConfiguration(shardRecordProcessorFactory);
@@ -173,6 +174,10 @@ public class MultiLangDaemonConfigurationTest {
                 60000,
                 ((PollingConfig) resolvedConfiguration.getRetrievalConfig().retrievalSpecificConfig())
                         .idleTimeBetweenReadsInMillis());
+        assertEquals(
+                60000,
+                ((PollingConfig) resolvedConfiguration.getRetrievalConfig().retrievalSpecificConfig())
+                        .idleMillisAfterThrottle());
         assertTrue(((PollingConfig) resolvedConfiguration.getRetrievalConfig().retrievalSpecificConfig())
                 .usePollingConfigIdleTimeValue());
     }

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/PollingConfigBeanTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/PollingConfigBeanTest.java
@@ -42,6 +42,7 @@ public class PollingConfigBeanTest {
         pollingConfigBean.setMaxGetRecordsThreadPool(20);
         pollingConfigBean.setMaxRecords(5000);
         pollingConfigBean.setRetryGetRecordsInSeconds(30);
+        pollingConfigBean.setIdleMillisAfterThrottle(1500);
 
         ConvertUtilsBean convertUtilsBean = new ConvertUtilsBean();
         BeanUtilsBean utilsBean = new BeanUtilsBean(convertUtilsBean);
@@ -57,6 +58,7 @@ public class PollingConfigBeanTest {
         assertThat(
                 pollingConfig.idleTimeBetweenReadsInMillis(),
                 equalTo(pollingConfigBean.getIdleTimeBetweenReadsInMillis()));
+        assertThat(pollingConfig.idleMillisAfterThrottle(), equalTo(pollingConfigBean.getIdleMillisAfterThrottle()));
         assertThat(
                 pollingConfig.maxGetRecordsThreadPool(),
                 equalTo(Optional.of(pollingConfigBean.getMaxGetRecordsThreadPool())));

--- a/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
+++ b/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
@@ -57,6 +57,9 @@ shardSyncIntervalMillis = 60000
 # Max records to fetch from Kinesis in a single GetRecords call.
 maxRecords = 10000
 
+# Idle time between record after throttle.
+idleMillisAfterThrottle = 1500
+
 # Idle time between record reads in milliseconds.
 idleTimeBetweenReadsInMillis = 1000
 

--- a/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
+++ b/amazon-kinesis-client-multilang/src/test/resources/multilang.properties
@@ -57,7 +57,7 @@ shardSyncIntervalMillis = 60000
 # Max records to fetch from Kinesis in a single GetRecords call.
 maxRecords = 10000
 
-# Idle time between record after throttle.
+# Idle time after record read throttle in milliseconds.
 idleMillisAfterThrottle = 1500
 
 # Idle time between record reads in milliseconds.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsFetcherFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsFetcherFactory.java
@@ -87,7 +87,7 @@ public interface RecordsFetcherFactory {
     long idleMillisBetweenCalls();
 
     /**
-     * Sets the minimum idle time after encountering a throttling exception.
+     * Sets the idle time after encountering a throttling exception.
      *
      * @param idleMillisAfterThrottle Sleep millis after a throttling exception.
      */

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsFetcherFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsFetcherFactory.java
@@ -85,4 +85,13 @@ public interface RecordsFetcherFactory {
     void idleMillisBetweenCalls(long idleMillisBetweenCalls);
 
     long idleMillisBetweenCalls();
+
+    /**
+     * Sets the minimum idle time after encountering a throttling exception.
+     *
+     * @param idleMillisAfterThrottle Sleep millis after a throttling exception.
+     */
+    void idleMillisAfterThrottle(long idleMillisAfterThrottle);
+
+    long idleMillisAfterThrottle();
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -80,7 +80,7 @@ public class PollingConfig implements RetrievalSpecificConfig {
 
     /**
      * Milliseconds publisher should sleep after encountering throttling error
-     * during call to {@link KinesisAsyncClient#getRecords(GetRecordsRequest)}.
+     * before next call to {@link KinesisAsyncClient#getRecords(GetRecordsRequest)}.
      *
      * <p>
      * Default value: 1500L

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -43,6 +43,7 @@ public class PollingConfig implements RetrievalSpecificConfig {
     public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
     public static final int DEFAULT_MAX_RECORDS = 10000;
+    public static final long DEFAULT_THROTTLE_MILLIS = 1500L;
 
     /**
      * Configurable functional interface to override the existing DataFetcher.
@@ -76,6 +77,16 @@ public class PollingConfig implements RetrievalSpecificConfig {
      * </p>
      */
     private int maxRecords = DEFAULT_MAX_RECORDS;
+
+    /**
+     * Milliseconds publisher should sleep after encountering throttling error
+     * during call to {@link KinesisAsyncClient#getRecords(GetRecordsRequest)}.
+     *
+     * <p>
+     * Default value: 1500L
+     * </p>
+     */
+    private long idleMillisAfterThrottle = DEFAULT_THROTTLE_MILLIS;
 
     /**
      * @param streamName    Name of Kinesis stream.
@@ -166,6 +177,7 @@ public class PollingConfig implements RetrievalSpecificConfig {
         if (usePollingConfigIdleTimeValue) {
             recordsFetcherFactory.idleMillisBetweenCalls(idleTimeBetweenReadsInMillis);
         }
+        recordsFetcherFactory.idleMillisAfterThrottle(idleMillisAfterThrottle);
         return new SynchronousBlockingRetrievalFactory(
                 streamName(),
                 kinesisClient(),

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -290,7 +290,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
             final MetricsFactory metricsFactory,
             final String operation,
             final String shardId,
-            @NonNull final ThrottlingReporter throttlingReporter) {
+            final ThrottlingReporter throttlingReporter) {
         this(
                 maxPendingProcessRecordsInput,
                 maxByteSize,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -61,6 +61,7 @@ import software.amazon.kinesis.retrieval.RecordsDeliveryAck;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RecordsRetrieved;
 import software.amazon.kinesis.retrieval.RetryableRetrievalException;
+import software.amazon.kinesis.retrieval.ThrottlingReporter;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 import static software.amazon.kinesis.common.DiagnosticUtils.takeDelayedDeliveryActionIfRequired;
@@ -109,6 +110,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
     private boolean wasReset = false;
     private Instant lastEventDeliveryTime = Instant.EPOCH;
     private final RequestDetails lastSuccessfulRequestDetails = new RequestDetails();
+    private final ThrottlingReporter throttlingReporter;
 
     @Data
     @Accessors(fluent = true)
@@ -233,6 +235,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
             @NonNull final MetricsFactory metricsFactory,
             @NonNull final String operation,
             @NonNull final String shardId,
+            @NonNull final ThrottlingReporter throttlingReporter,
             final long awaitTerminationTimeoutMillis) {
         this.getRecordsRetrievalStrategy = getRecordsRetrievalStrategy;
         this.maxRecordsPerCall = maxRecordsPerCall;
@@ -248,6 +251,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
         this.idleMillisBetweenCalls = idleMillisBetweenCalls;
         this.defaultGetRecordsCacheDaemon = new DefaultGetRecordsCacheDaemon();
         Validate.notEmpty(operation, "Operation cannot be empty");
+        this.throttlingReporter = throttlingReporter;
         this.operation = operation;
         this.streamId = this.getRecordsRetrievalStrategy.dataFetcher().getStreamIdentifier();
         this.streamAndShardId = this.streamId.serialize() + ":" + shardId;
@@ -279,7 +283,8 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
             final long idleMillisBetweenCalls,
             final MetricsFactory metricsFactory,
             final String operation,
-            final String shardId) {
+            final String shardId,
+            @NonNull final ThrottlingReporter throttlingReporter) {
         this(
                 maxPendingProcessRecordsInput,
                 maxByteSize,
@@ -291,6 +296,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                 metricsFactory,
                 operation,
                 shardId,
+                throttlingReporter,
                 DEFAULT_AWAIT_TERMINATION_TIMEOUT_MILLIS);
     }
 
@@ -555,6 +561,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                             recordsRetrieved.lastBatchSequenceNumber);
                     addArrivedRecordsInput(recordsRetrieved);
                     drainQueueForRequests();
+                    throttlingReporter.success();
                 } catch (PositionResetException pse) {
                     throw pse;
                 } catch (RetryableRetrievalException rre) {
@@ -587,7 +594,9 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                     // Update the lastSuccessfulCall if we get a throttling exception so that we back off idleMillis
                     // for the next call
                     lastSuccessfulCall = Instant.now();
+                    throttlingReporter.throttled();
                     log.error("{} :  Exception thrown while fetching records from Kinesis", streamAndShardId, e);
+                    log.info("Backing off for {} millis - idleMillisBetweenCalls", idleMillisBetweenCalls);
                 } catch (SdkException e) {
                     log.error("{} :  Exception thrown while fetching records from Kinesis", streamAndShardId, e);
                 } finally {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
@@ -24,6 +24,7 @@ import software.amazon.kinesis.retrieval.DataFetchingStrategy;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 import software.amazon.kinesis.retrieval.RecordsFetcherFactory;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
+import software.amazon.kinesis.retrieval.ThrottlingReporter;
 
 @Slf4j
 @KinesisClientInternalApi
@@ -32,6 +33,7 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
     private int maxByteSize = 8 * 1024 * 1024;
     private int maxRecordsCount = 30000;
     private long idleMillisBetweenCalls = 1500L;
+    private int maxConsecutiveThrottles = 5;
     private DataFetchingStrategy dataFetchingStrategy = DataFetchingStrategy.DEFAULT;
 
     @Override
@@ -56,7 +58,8 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
                 idleMillisBetweenCalls,
                 metricsFactory,
                 "ProcessTask",
-                shardId);
+                shardId,
+                new ThrottlingReporter(maxConsecutiveThrottles, shardId));
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
@@ -33,6 +33,7 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
     private int maxByteSize = 8 * 1024 * 1024;
     private int maxRecordsCount = 30000;
     private long idleMillisBetweenCalls = 1500L;
+    private long idleMillisAfterThrottle = 1500L;
     private int maxConsecutiveThrottles = 5;
     private DataFetchingStrategy dataFetchingStrategy = DataFetchingStrategy.DEFAULT;
 
@@ -56,6 +57,7 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
                                 .setNameFormat("prefetch-cache-" + shardId + "-%04d")
                                 .build()),
                 idleMillisBetweenCalls,
+                idleMillisAfterThrottle,
                 metricsFactory,
                 "ProcessTask",
                 shardId,
@@ -88,6 +90,11 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
     }
 
     @Override
+    public void idleMillisAfterThrottle(final long idleMillisAfterThrottle) {
+        this.idleMillisAfterThrottle = idleMillisAfterThrottle;
+    }
+
+    @Override
     public int maxPendingProcessRecordsInput() {
         return maxPendingProcessRecordsInput;
     }
@@ -110,5 +117,10 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
     @Override
     public long idleMillisBetweenCalls() {
         return idleMillisBetweenCalls;
+    }
+
+    @Override
+    public long idleMillisAfterThrottle() {
+        return idleMillisAfterThrottle;
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -48,6 +48,7 @@ import software.amazon.kinesis.metrics.NullMetricsFactory;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 import software.amazon.kinesis.retrieval.RecordsRetrieved;
+import software.amazon.kinesis.retrieval.ThrottlingReporter;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 import static org.junit.Assert.assertEquals;
@@ -126,6 +127,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
                 new NullMetricsFactory(),
                 operation,
                 "test-shard",
+                new ThrottlingReporter(5, "test-shard"),
                 AWAIT_TERMINATION_TIMEOUT);
     }
 
@@ -186,6 +188,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
                 new NullMetricsFactory(),
                 operation,
                 "test-shard-2",
+                new ThrottlingReporter(5, "test-shard"),
                 AWAIT_TERMINATION_TIMEOUT);
 
         getRecordsCache.start(extendedSequenceNumber, initialPosition);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -79,6 +79,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
     private static final int MAX_RECORDS_COUNT = 30_000;
     private static final int MAX_RECORDS_PER_CALL = 10_000;
     private static final long IDLE_MILLIS_BETWEEN_CALLS = 500L;
+    private static final long IDLE_MILLIS_AFTER_THROTTLE = 500L;
     private static final long AWAIT_TERMINATION_TIMEOUT = 1L;
     private static final MetricsFactory NULL_METRICS_FACTORY = new NullMetricsFactory();
 
@@ -124,6 +125,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
                 getRecordsRetrievalStrategy,
                 executorService,
                 IDLE_MILLIS_BETWEEN_CALLS,
+                IDLE_MILLIS_AFTER_THROTTLE,
                 new NullMetricsFactory(),
                 operation,
                 "test-shard",
@@ -185,6 +187,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
                 getRecordsRetrievalStrategy2,
                 executorService2,
                 IDLE_MILLIS_BETWEEN_CALLS,
+                IDLE_MILLIS_AFTER_THROTTLE,
                 new NullMetricsFactory(),
                 operation,
                 "test-shard-2",

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -845,9 +845,9 @@ public class PrefetchRecordsPublisherTest {
         getRecordsCache.start(sequenceNumber, initialPosition);
 
         Instant startTime = Instant.now();
-        BlockingUtils.blockUntilRecordsAvailable(this::evictPublishedEvent, idleMillisAfterThrottle); // expected ~2000L
+        BlockingUtils.blockUntilRecordsAvailable(this::evictPublishedEvent, idleMillisAfterThrottle);
         Instant endTime = Instant.now();
-        long elapsedMillis = Duration.between(startTime, endTime).toMillis(); // expected ~2100ms
+        long elapsedMillis = Duration.between(startTime, endTime).toMillis();
         assertThat(elapsedMillis, greaterThanOrEqualTo(idleMillisAfterThrottle));
         assertThat(elapsedMillis, lessThanOrEqualTo(idleMillisAfterThrottle + idleMillisBetweenCalls));
     }
@@ -867,9 +867,9 @@ public class PrefetchRecordsPublisherTest {
         getRecordsCache.start(sequenceNumber, initialPosition);
 
         Instant startTime = Instant.now();
-        BlockingUtils.blockUntilRecordsAvailable(this::evictPublishedEvent, idleMillisBetweenCalls); // expected ~1000L
+        BlockingUtils.blockUntilRecordsAvailable(this::evictPublishedEvent, idleMillisBetweenCalls);
         Instant endTime = Instant.now();
-        long elapsedMillis = Duration.between(startTime, endTime).toMillis(); // expected ~1100ms
+        long elapsedMillis = Duration.between(startTime, endTime).toMillis();
         assertThat(elapsedMillis, greaterThanOrEqualTo(idleMillisBetweenCalls));
     }
 


### PR DESCRIPTION
1. Implements a new polling config property `idleMillisAfterThrottle` to determine how long to backoff when publisher encounters `ProvisionedThroughputExceededException`.

2. Reintroduces the throttleReporter for improved logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
